### PR TITLE
Remove should_format? tests

### DIFF
--- a/apps/language_server/test/providers/formatting_test.exs
+++ b/apps/language_server/test/providers/formatting_test.exs
@@ -373,19 +373,4 @@ defmodule ElixirLS.LanguageServer.Providers.FormattingTest do
              ]
     end)
   end
-
-  test "honors :inputs when deciding to format" do
-    file = __ENV__.file
-    uri = SourceFile.path_to_uri(file)
-    project_dir = Path.dirname(file)
-
-    opts = []
-    assert Formatting.should_format?(uri, project_dir, opts[:inputs])
-
-    opts = [inputs: ["*.exs"]]
-    assert Formatting.should_format?(uri, project_dir, opts[:inputs])
-
-    opts = [inputs: ["*.ex"]]
-    refute Formatting.should_format?(uri, project_dir, opts[:inputs])
-  end
 end


### PR DESCRIPTION
This changes is to try to solve unit tests fail step by step. The first error that I encountered is that `Formatting.should_format?` undefined error in test file because it was remove in your PR. This change fix that by 
remove tests against that function.